### PR TITLE
Forward error from TypeDB server to the MCP client

### DIFF
--- a/common.py
+++ b/common.py
@@ -1,5 +1,6 @@
 import requests
 import config
+import json
 
 
 def get_auth_token() -> str:
@@ -8,5 +9,52 @@ def get_auth_token() -> str:
         f"{config.TYPEDB_URL}/v1/signin",
         json={"username": config.TYPEDB_USERNAME, "password": config.TYPEDB_PASSWORD}
     )
-    response.raise_for_status()
+    handle_typedb_response(response)
     return response.json()["token"]
+
+
+def handle_typedb_response(response: requests.Response) -> None:
+    """Check response status and raise an error with TypeDB error details if needed.
+    
+    This ensures that TypeDB error messages are properly extracted from the response
+    and propagated to the MCP client.
+    
+    Args:
+        response: The requests.Response object to check
+        
+    Raises:
+        requests.HTTPError: If the response status indicates an error, with TypeDB error details included
+    """
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as e:
+        # Try to extract error details from TypeDB response
+        error_message = f"TypeDB error (HTTP {response.status_code})"
+        
+        try:
+            # TypeDB typically returns JSON error responses
+            error_data = response.json()
+            if isinstance(error_data, dict):
+                # Extract common error fields
+                if "message" in error_data:
+                    error_message = f"TypeDB error: {error_data['message']}"
+                elif "error" in error_data:
+                    error_message = f"TypeDB error: {error_data['error']}"
+                else:
+                    # Include the full error data if available
+                    error_message = f"TypeDB error: {json.dumps(error_data)}"
+            elif isinstance(error_data, str):
+                error_message = f"TypeDB error: {error_data}"
+        except (ValueError, json.JSONDecodeError):
+            # If response is not JSON, try to get text
+            try:
+                error_text = response.text
+                if error_text:
+                    error_message = f"TypeDB error: {error_text}"
+            except Exception:
+                pass  # Fall back to default error message
+        
+        # Create a new HTTPError with the enhanced error message
+        # Preserve the original response object
+        http_error = requests.HTTPError(error_message, response=response)
+        raise http_error from e

--- a/common.py
+++ b/common.py
@@ -29,32 +29,6 @@ def handle_typedb_response(response: requests.Response) -> None:
         response.raise_for_status()
     except requests.HTTPError as e:
         # Try to extract error details from TypeDB response
-        error_message = f"TypeDB error (HTTP {response.status_code})"
-        
-        try:
-            # TypeDB typically returns JSON error responses
-            error_data = response.json()
-            if isinstance(error_data, dict):
-                # Extract common error fields
-                if "message" in error_data:
-                    error_message = f"TypeDB error: {error_data['message']}"
-                elif "error" in error_data:
-                    error_message = f"TypeDB error: {error_data['error']}"
-                else:
-                    # Include the full error data if available
-                    error_message = f"TypeDB error: {json.dumps(error_data)}"
-            elif isinstance(error_data, str):
-                error_message = f"TypeDB error: {error_data}"
-        except (ValueError, json.JSONDecodeError):
-            # If response is not JSON, try to get text
-            try:
-                error_text = response.text
-                if error_text:
-                    error_message = f"TypeDB error: {error_text}"
-            except Exception:
-                pass  # Fall back to default error message
-        
-        # Create a new HTTPError with the enhanced error message
-        # Preserve the original response object
-        http_error = requests.HTTPError(error_message, response=response)
+        error_data = response.json()
+        http_error = requests.HTTPError(error_data, response=response)
         raise http_error from e

--- a/database.py
+++ b/database.py
@@ -1,6 +1,6 @@
 import requests
 import config
-from common import get_auth_token
+from common import get_auth_token, handle_typedb_response
 
 
 def list_databases() -> str:
@@ -10,7 +10,7 @@ def list_databases() -> str:
         f"{config.TYPEDB_URL}/v1/databases",
         headers={"Authorization": f"Bearer {token}"}
     )
-    response.raise_for_status()
+    handle_typedb_response(response)
     return response.text
 
 
@@ -21,7 +21,7 @@ def create_database(name: str) -> str:
         f"{config.TYPEDB_URL}/v1/databases/{name}",
         headers={"Authorization": f"Bearer {token}"}
     )
-    response.raise_for_status()
+    handle_typedb_response(response)
     return f"Database '{name}' created successfully"
 
 
@@ -32,7 +32,7 @@ def delete_database(name: str) -> str:
         f"{config.TYPEDB_URL}/v1/databases/{name}",
         headers={"Authorization": f"Bearer {token}"}
     )
-    response.raise_for_status()
+    handle_typedb_response(response)
     return f"Database '{name}' deleted successfully"
 
 
@@ -43,5 +43,5 @@ def database_schema(name: str) -> str:
         f"{config.TYPEDB_URL}/v1/databases/{name}/schema",
         headers={"Authorization": f"Bearer {token}"}
     )
-    response.raise_for_status()
+    handle_typedb_response(response)
     return response.text

--- a/query.py
+++ b/query.py
@@ -1,6 +1,6 @@
 import requests
 import config
-from common import get_auth_token
+from common import get_auth_token, handle_typedb_response
 
 
 def query(query: str, database: str, transaction_type: str = "read") -> str:
@@ -29,5 +29,5 @@ def query(query: str, database: str, transaction_type: str = "read") -> str:
             "commit": transaction_type in ("write", "schema")
         }
     )
-    response.raise_for_status()
+    handle_typedb_response(response)
     return response.text

--- a/user.py
+++ b/user.py
@@ -1,6 +1,6 @@
 import requests
 import config
-from common import get_auth_token
+from common import get_auth_token, handle_typedb_response
 
 
 def list_users() -> str:
@@ -10,7 +10,7 @@ def list_users() -> str:
         f"{config.TYPEDB_URL}/v1/users",
         headers={"Authorization": f"Bearer {token}"}
     )
-    response.raise_for_status()
+    handle_typedb_response(response)
     return response.text
 
 
@@ -22,7 +22,7 @@ def create_user(username: str, password: str) -> str:
         headers={"Authorization": f"Bearer {token}"},
         json={"password": password}
     )
-    response.raise_for_status()
+    handle_typedb_response(response)
     return f"User '{username}' created successfully"
 
 
@@ -33,5 +33,5 @@ def delete_user(username: str) -> str:
         f"{config.TYPEDB_URL}/v1/users/{username}",
         headers={"Authorization": f"Bearer {token}"}
     )
-    response.raise_for_status()
+    handle_typedb_response(response)
     return f"User '{username}' deleted successfully"


### PR DESCRIPTION
Forward error from TypeDB server to the MCP client, so that one has enough information about how to deal with it.